### PR TITLE
add more examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,209 @@
 # ember-concurrency-test-controller
 
-This README outlines the details of collaborating on this Ember addon.
+This library provides a set of tools to pause async behavior in your tests to make it easier to assert intermediate state.
 
-## Installation
+## Usage
+--------
 
-* `git clone <repository-url>` this repository
-* `cd ember-concurrency-test-controller`
-* `yarn install`
+### Installation
 
-## Running
+* `ember install ember-concurrency-test-controller`
+
+### Acceptance Test
+
+Suppose that we had a maybe-slow-loading route that rendered a loading template, with a model hook that looks like:
+
+```js
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model({ id }) {
+    return this.store.find('friends', id);
+  }
+})
+```
+
+And, an acceptance test that looked something like this:
+
+```js
+it('shows a friend', async function(assert) {
+  visit('/friends/1');
+
+  // Where do we assert this!?!
+  // assert.ok(find('.loading-spinner').length, 'loading screen visible!');
+
+  await andThen(() => {});
+
+  assert.ok(find('.friend-name').text().trim(), 'Steve');
+});
+```
+
+If we were to uncomment the `assert` that checks for the loading spinner, it's _possible_ that it has rendered by then; but not necessarily a guarantee. (This could lead to a flaky test!)
+
+Instead, with this library, we can explicitly pause the model hook so we can test the loading state.
+
+```js
+import Route from '@ember/routing/route';
+import { pausable } from 'ember-concurrency-test-controller';
+
+export default Route.extend({
+  model({ id }) {
+    const friend = this.store.find('friends', id);
+    return pausable(friend, 'friend-promise');
+  }
+})
+```
+
+And, in our test:
+
+(_note:_ You should always call `reset()` in the `afterEach` hook when using `pauseOn`)
+
+```js
+import { pauseOn, reset } from 'ember-concurrency-test-controller/test-support';
+
+moduleForAcceptance('Acceptance | friend', {
+  afterEach() {
+    reset();
+  }
+});
+
+it('shows a friend', async function(assert) {
+  const { resume, awaitPause } = pauseOn('friend-promise');
+
+  visit('/friends/1');
+
+  await awaitPause();
+
+  assert.ok(find('.loading-spinner').length, 'loading screen visible!');
+
+  resume();
+
+  await andThen(() => {});
+
+  assert.ok(find('.friend-name').text().trim(), 'Steve');
+});
+```
+
+### With `ember-concurrecncy`
+
+Let's imagine a component that, when it renders, it pushes items onto a list every second.
+
+There are two things I'd like to think about when testing this componen:
+
+- I want to test each step of the state as it changes
+- I want the test to run fast (no need to wait a second between each step)
+
+The component may look something like this:
+
+```js
+export default Component.extend({
+  didInsertElement() {
+    set(this, 'objects', A([]));
+    get(this, 'myTask').perform();
+  },
+
+  myTask: task(function *() {
+    const objects = get(this, 'objects');
+    const waitTime = testing ? 0 : 1000;
+    let idx = -1;
+
+    while (++idx < 5) {
+      objects.pushObject({ name: `Step ${idx}` });
+      yield timeout(waitTime);
+    }
+  })
+});
+```
+
+```hbs
+<ul>
+  {{#each objects as |object|}}
+    <li>{{object.name}}</li>
+  {{/each}}
+</ul>
+```
+
+By replacing the `yield` statement with...
+
+```js
+yield pausable(timeout(waitTime), 'state-progressor');
+```
+
+...we can setup our integration test like this:
+
+```js
+import { pauseOn } from 'ember-concurrency-test-controller/test-support';
+import wait from 'ember-test-helpers/wait';
+
+test('it renders each of the steps', async function(assert) {
+  const { resume, awaitPause } = pauseOn('state-progressor');
+
+  this.render(hbs`{{state-progressor}}`);
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 1);
+  resume();
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 2);
+  resume();
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 3);
+  resume();
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 4);
+  resume();
+
+  await wait();
+  assert.equal(this.$('ul > li').length, 5);
+});
+```
+
+### API
+
+#### `ember-concurrency-test-controller`
+
+- `pausable(yieldable: Any, tokenName: String)`
+  In a test environment and when a `pauseOn` is registered with the given `tokenName`, this method will return a promise that resolves
+  when `pauseOn(tokenName).resume()` is called and resolves with the `yieldable`.
+
+  In non-test environments, or when there is no `pauseOn` registered, this will return the `yieldable` directly.
+
+#### `ember-concurrency-test-controller/test-support`
+
+- `pauseOn(tokenName: String)`
+  This regsiters a pause to happen when a corresponding `pausable` is reached in the code.
+
+  This method returns a `PauseToken`.
+
+- `PauseToken`
+  - `resume()`
+    This will resolve the promise that is pausing the promise chain.
+
+  - `awaitPause()`
+    This returns a promise that will resolve the next time the corresponding `pausable()` block is hit.
+
+  - `throwException()`
+    This will cause the paused promise to reject, instead of resolve.
+
+
+## Collaborating
+--------
+
+### Running
 
 * `ember serve`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 
-## Running Tests
+### Running Tests
 
 * `yarn test` (Runs `ember try:each` to test your addon against multiple Ember versions)
 * `ember test`
 * `ember test --server`
 
-## Building
+### Building
 
 * `ember build`
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ it('shows a friend', async function(assert) {
 
 Let's imagine a component that, when it renders, it pushes items onto a list every second.
 
-There are two things I'd like to think about when testing this componen:
+There are two things I'd like to think about when testing this component:
 
 - I want to test each step of the state as it changes
 - I want the test to run fast (no need to wait a second between each step)

--- a/tests/acceptance/friend-test.js
+++ b/tests/acceptance/friend-test.js
@@ -1,0 +1,42 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { pauseOn, reset } from 'ember-concurrency-test-controller/test-support'
+
+moduleForAcceptance('Acceptance | friend', {
+  afterEach() {
+    reset();
+  }
+});
+
+test('visiting /friend/1', async function(assert) {
+  const { resume, awaitPause } = pauseOn('friend-promise');
+
+  visit('/friend/1');
+
+  await awaitPause();
+
+  assert.ok(find('.loading').length, 'loading screen visible');
+
+  resume();
+
+  await andThen(() => {});
+
+  assert.ok(find('.friend-name').text().trim(), 'Steve');
+  assert.ok(find('.friend-id').text().trim(), '1');
+});
+
+test('erroring on /friend/1', async function(assert) {
+  const { throwException, awaitPause } = pauseOn('friend-promise');
+
+  visit('/friend/1');
+
+  await awaitPause();
+
+  assert.ok(find('.loading').length, 'loading screen visible');
+
+  throwException();
+
+  await andThen(() => {});
+
+  assert.ok(find('.error-state').length, 'error state visible');
+});

--- a/tests/dummy/app/components/state-progressor.js
+++ b/tests/dummy/app/components/state-progressor.js
@@ -1,0 +1,30 @@
+import Component from '@ember/component';
+import layout from '../templates/components/state-progressor';
+import { get, set } from '@ember/object';
+import { task, timeout } from 'ember-concurrency';
+import { pausable } from 'ember-concurrency-test-controller';
+import Ember from 'ember';
+import { A } from '@ember/array';
+
+const { testing } = Ember;
+
+export default Component.extend({
+  layout,
+  objects: null,
+
+  didInsertElement() {
+    set(this, 'objects', A([]));
+    get(this, 'myTask').perform();
+  },
+
+  myTask: task(function *() {
+    const objects = get(this, 'objects');
+    const waitTime = testing ? 0 : 1000;
+    let idx = -1;
+
+    while (++idx < 5) {
+      objects.pushObject({ name: `Step ${idx}` });
+      yield pausable(timeout(waitTime), 'state-progressor');
+    }
+  })
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
+  this.route('friend', { path: 'friend/:id' });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/friend.js
+++ b/tests/dummy/app/routes/friend.js
@@ -1,0 +1,21 @@
+import Route from '@ember/routing/route';
+import { defer } from 'rsvp';
+import Ember from 'ember';
+import { pausable } from 'ember-concurrency-test-controller';
+
+const { testing } = Ember;
+
+export default Route.extend({
+  model({ id }) {
+    const { resolve, promise } = defer();
+
+    setTimeout(() => {
+      resolve({
+        id,
+        name: 'Steve'
+      });
+    }, testing ? 0 : 2000);
+
+    return pausable(promise, 'friend-promise');
+  }
+});

--- a/tests/dummy/app/templates/components/state-progressor.hbs
+++ b/tests/dummy/app/templates/components/state-progressor.hbs
@@ -1,0 +1,5 @@
+<ul>
+  {{#each objects as |object|}}
+    <li>{{object.name}}</li>
+  {{/each}}
+</ul>

--- a/tests/dummy/app/templates/error.hbs
+++ b/tests/dummy/app/templates/error.hbs
@@ -1,0 +1,1 @@
+<div class="error-state">ERROR!</div>

--- a/tests/dummy/app/templates/friend.hbs
+++ b/tests/dummy/app/templates/friend.hbs
@@ -1,0 +1,3 @@
+<h1 class="friend-name">{{model.name}}</h1>
+<p class="friend-id">ID: {{model.id}}</p>
+{{state-progressor}}

--- a/tests/dummy/app/templates/loading.hbs
+++ b/tests/dummy/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+<h1 class="loading">LOADING!</h1>

--- a/tests/integration/components/state-progressor-test.js
+++ b/tests/integration/components/state-progressor-test.js
@@ -1,0 +1,36 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { pauseOn, reset } from 'ember-concurrency-test-controller/test-support';
+import wait from 'ember-test-helpers/wait';
+
+moduleForComponent('state-progressor', 'Integration | Component | state progressor', {
+  integration: true,
+  afterEach() {
+    reset();
+  }
+});
+
+test('it renders each of the steps', async function(assert) {
+  const { resume, awaitPause } = pauseOn('state-progressor');
+
+  this.render(hbs`{{state-progressor}}`);
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 1);
+  resume();
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 2);
+  resume();
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 3);
+  resume();
+
+  await awaitPause();
+  assert.equal(this.$('ul > li').length, 4);
+  resume();
+
+  await wait();
+  assert.equal(this.$('ul > li').length, 5);
+});

--- a/tests/unit/utils/pausable/ajax-test.js
+++ b/tests/unit/utils/pausable/ajax-test.js
@@ -1,0 +1,70 @@
+import { pausable } from 'ember-concurrency-test-controller';
+import { pauseOn, reset } from 'ember-concurrency-test-controller/test-support'
+import { module, test } from 'qunit';
+import { resolve } from 'rsvp';
+import wait from 'ember-test-helpers/wait';
+
+module('pausable | promise-y stuff', {
+  afterEach() {
+    reset();
+  }
+});
+
+test('it can handle pausing on promisey-stuff', async function(assert) {
+  let state = 0;
+  const { resume, awaitPause } = pauseOn('pause-token');
+
+  resolve().then(() => {
+    state = 1;
+    return pausable(resolve(), 'pause-token');
+  }).then(() => {
+    state = 2;
+  });
+
+  assert.equal(state, 0);
+
+  await awaitPause();
+
+  assert.equal(state, 1);
+
+  resume();
+
+  await wait();
+
+  assert.equal(state, 2);
+});
+
+
+test('it can handle pausing on multiple promises', async function(assert) {
+  let state = 0;
+  const { resume: resume1, awaitPause: awaitPause1 } = pauseOn('pause-token-1');
+  const { resume: resume2, awaitPause: awaitPause2 } = pauseOn('pause-token-2');
+
+  resolve().then(() => {
+    state = 1;
+    return pausable(resolve(), 'pause-token-1');
+  }).then(() => {
+    state = 2;
+    return pausable(resolve(), 'pause-token-2');
+  }).then(() => {
+    state = 3;
+  });
+
+  assert.equal(state, 0);
+
+  await awaitPause1();
+
+  assert.equal(state, 1);
+
+  resume1();
+
+  await awaitPause2();
+
+  assert.equal(state, 2);
+
+  resume2();
+
+  await wait();
+
+  assert.equal(state, 3);
+});


### PR DESCRIPTION
In doing these additional examples and documentation, I think it became clear that `ember-concurrency-test-controller` is probably not the right name for this. 

Ideas for names? 

Thoughts:

- `ember-pausable-test`
- `ember-pause-async`